### PR TITLE
Autocommit setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,10 +120,10 @@ Each database defintions can have the following keys:
   with very long interval, to avoid holding idle connections.
 
 ``autocommit``:
-  whether to set autocommit for the database connection. If not specified, defaults 
-  to ``true``.  Setting this option to ``false`` might be useful if you run into 
-  issues with DB2. 
-  
+  whether to set autocommit for the database connection. If not specified,
+  defaults to ``true``.  This should only be changed to ``false`` if specific
+  queries require it.
+
 ``labels``:
   an optional mapping of label names and values to tag metrics collected from each database.
   When labels are used, all databases must define the same set of labels.

--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,11 @@ Each database defintions can have the following keys:
   this option to ``false`` might be useful if queries on a database are run
   with very long interval, to avoid holding idle connections.
 
+``autocommit``:
+  whether to set autocommit for the database connection. If not specified, defaults 
+  to ``true``.  Setting this option to ``false`` might be useful if you run into 
+  issues with DB2. 
+  
 ``labels``:
   an optional mapping of label names and values to tag metrics collected from each database.
   When labels are used, all databases must define the same set of labels.

--- a/query_exporter/config.py
+++ b/query_exporter/config.py
@@ -92,9 +92,9 @@ def _get_databases(
                 name,
                 _resolve_dsn(config["dsn"], env),
                 connect_sql=config.get("connect-sql"),
-                keep_connected=bool(config.get("keep-connected", True)),
+                keep_connected=config.get("keep-connected", True),
+                autocommit=config.get("autocommit", True),
                 labels=labels,
-                autocommit=bool(config.get("autocommit", True)),
             )
     except Exception as e:
         raise ConfigError(str(e))

--- a/query_exporter/config.py
+++ b/query_exporter/config.py
@@ -94,6 +94,7 @@ def _get_databases(
                 connect_sql=config.get("connect-sql"),
                 keep_connected=bool(config.get("keep-connected", True)),
                 labels=labels,
+                autocommit=bool(config.get("autocommit", True)),
             )
     except Exception as e:
         raise ConfigError(str(e))

--- a/query_exporter/db.py
+++ b/query_exporter/db.py
@@ -172,16 +172,18 @@ class DataBase:
         connect_sql: Optional[List[str]] = None,
         keep_connected: Optional[bool] = True,
         labels: Optional[Dict[str, str]] = None,
+        autocommit: Optional[bool] = True
     ):
         self.name = name
         self.dsn = dsn
         self.connect_sql = connect_sql or []
         self.keep_connected = keep_connected
         self.labels = labels or {}
+        self.autocommit = autocommit
         self._connect_lock = asyncio.Lock()
         try:
             self._engine = sqlalchemy.create_engine(
-                dsn, strategy=ASYNCIO_STRATEGY, execution_options={"autocommit": True},
+                dsn, strategy=ASYNCIO_STRATEGY, execution_options={"autocommit": self.autocommit},
             )
         except ImportError as error:
             raise self._db_error(f'module "{error.name}" not found', fatal=True)

--- a/query_exporter/db.py
+++ b/query_exporter/db.py
@@ -171,19 +171,21 @@ class DataBase:
         dsn: str,
         connect_sql: Optional[List[str]] = None,
         keep_connected: Optional[bool] = True,
+        autocommit: Optional[bool] = True,
         labels: Optional[Dict[str, str]] = None,
-        autocommit: Optional[bool] = True
     ):
         self.name = name
         self.dsn = dsn
         self.connect_sql = connect_sql or []
         self.keep_connected = keep_connected
-        self.labels = labels or {}
         self.autocommit = autocommit
+        self.labels = labels or {}
         self._connect_lock = asyncio.Lock()
         try:
             self._engine = sqlalchemy.create_engine(
-                dsn, strategy=ASYNCIO_STRATEGY, execution_options={"autocommit": self.autocommit},
+                dsn,
+                strategy=ASYNCIO_STRATEGY,
+                execution_options={"autocommit": self.autocommit},
             )
         except ImportError as error:
             raise self._db_error(f'module "{error.name}" not found', fatal=True)

--- a/query_exporter/schemas/config.yaml
+++ b/query_exporter/schemas/config.yaml
@@ -75,6 +75,13 @@ definitions:
         patternProperties:
           ^[a-zA-Z_:][a-zA-Z0-9_:]*$:
             type: string
+      autocommit:
+        title: SQLAlchemy autocommit setting
+        description: >
+          Set autocommit for SQLAlchemy connections. Defaults to true. DB2 queries may need 
+          autocommit set to false to work properly
+        type: boolean
+        default: true
 
   metric:
     title: A Prometheus metric to export

--- a/query_exporter/schemas/config.yaml
+++ b/query_exporter/schemas/config.yaml
@@ -50,6 +50,12 @@ definitions:
           A string with database connection string, in the format
           dialect[+driver]://[username:password][@host:port]/database[?option=value&...]
         type: string
+      autocommit:
+        title: Whether to enable autocommit for queries
+        description: >
+          When set to false, don't autocommit after each query.
+        type: boolean
+        default: true
       keep-connected:
         title: Whether to keep the connection open for the database between queries
         description: >
@@ -75,13 +81,6 @@ definitions:
         patternProperties:
           ^[a-zA-Z_:][a-zA-Z0-9_:]*$:
             type: string
-      autocommit:
-        title: SQLAlchemy autocommit setting
-        description: >
-          Set autocommit for SQLAlchemy connections. Defaults to true. DB2 queries may need 
-          autocommit set to false to work properly
-        type: boolean
-        default: true
 
   metric:
     title: A Prometheus metric to export

--- a/query_exporter/tests/test_config.py
+++ b/query_exporter/tests/test_config.py
@@ -119,7 +119,7 @@ class TestLoadConfig:
         config = {
             "databases": {
                 "db1": {"dsn": "sqlite:///foo"},
-                "db2": {"dsn": "sqlite:///bar", "keep-connected": False},
+                "db2": {"dsn": "sqlite:///bar", "keep-connected": False, "autocommit": False},
             },
             "metrics": {},
             "queries": {},
@@ -133,9 +133,11 @@ class TestLoadConfig:
         assert database1.name == "db1"
         assert database1.dsn == "sqlite:///foo"
         assert database1.keep_connected
+        assert database1.autocommit 
         assert database2.name == "db2"
         assert database2.dsn == "sqlite:///bar"
         assert not database2.keep_connected
+        assert not database2.autocommit
 
     def test_load_databases_dsn_from_env(self, logger, write_config):
         """The database DSN can be loaded from env."""

--- a/query_exporter/tests/test_config.py
+++ b/query_exporter/tests/test_config.py
@@ -119,7 +119,11 @@ class TestLoadConfig:
         config = {
             "databases": {
                 "db1": {"dsn": "sqlite:///foo"},
-                "db2": {"dsn": "sqlite:///bar", "keep-connected": False, "autocommit": False},
+                "db2": {
+                    "dsn": "sqlite:///bar",
+                    "keep-connected": False,
+                    "autocommit": False,
+                },
             },
             "metrics": {},
             "queries": {},
@@ -133,11 +137,13 @@ class TestLoadConfig:
         assert database1.name == "db1"
         assert database1.dsn == "sqlite:///foo"
         assert database1.keep_connected
-        assert database1.autocommit 
+        assert database1.autocommit
+        assert database1._engine._execution_options == {"autocommit": True}
         assert database2.name == "db2"
         assert database2.dsn == "sqlite:///bar"
         assert not database2.keep_connected
         assert not database2.autocommit
+        assert database2._engine._execution_options == {"autocommit": False}
 
     def test_load_databases_dsn_from_env(self, logger, write_config):
         """The database DSN can be loaded from env."""

--- a/query_exporter/tests/test_db.py
+++ b/query_exporter/tests/test_db.py
@@ -211,7 +211,7 @@ class TestDataBase:
         assert 'module "psycopg2" not found' in caplog.text
 
     def test_instantiate_autocommit_false(self):
-        """autocommit can be set to false."""
+        """Query autocommit can be set to False."""
         db = DataBase("db", "sqlite:///foo", autocommit=False)
         assert not db.autocommit
 

--- a/query_exporter/tests/test_db.py
+++ b/query_exporter/tests/test_db.py
@@ -210,6 +210,11 @@ class TestDataBase:
         assert str(error.value) == 'module "psycopg2" not found'
         assert 'module "psycopg2" not found' in caplog.text
 
+    def test_instantiate_autocommit_false(self):
+        """autocommit can be set to false."""
+        db = DataBase("db", "sqlite:///foo", autocommit=False)
+        assert not db.autocommit
+
     @pytest.mark.parametrize("dsn", ["foo-bar", "unknown:///db"])
     def test_instantiate_invalid_dsn(self, caplog, dsn):
         """An error is raised if a the provided DSN is invalid."""


### PR DESCRIPTION
I have made autocommit configurable with the default = true. Some DB2 queries need autocommit = false. 

See [IBMCLI125e Error](https://www.ibm.com/support/pages/100-cte0100-db2-operation-failed-db2-information-hy010-ibmcli-driver-cli0125e-function-sequence)