### PR TITLE
Added file based config option for DSN

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,10 +106,15 @@ Each database defintions can have the following keys:
   See `SQLAlchemy documentation`_ for details on available engines and the
   `database-specific options`_ page for some extra details.
 
-  It's also possible to get the connection string from an environment variable
-  (e.g. ``$CONNECTION_STRING``) by setting ``dsn`` to::
+  It's also possible to get the connection string indirectly from other sources:
 
-    env:CONNECTION_STRING
+    - from an environment variable (e.g. ``$CONNECTION_STRING``) by setting ``dsn`` to::
+
+        env:CONNECTION_STRING
+
+    - from a file, containing only the DSN value, by setting ``dsn`` to::
+
+        file:/path/to/file
 
 ``connect-sql``:
   An optional list of queries to run right after database connection. This can

--- a/query_exporter/config.py
+++ b/query_exporter/config.py
@@ -283,6 +283,16 @@ def _resolve_dsn(dsn: str, env: Environ) -> str:
             raise ValueError(f'Undefined variable: "{varname}"')
         dsn = env[varname]
 
+    if dsn.startswith("file:"):
+        _, filename = dsn.split(":", 1)
+
+        try:
+            with open(filename) as fd:
+                dsn = fd.read().replace('\n', '')
+
+        except OSError as e:
+            raise ValueError(f'Unable to read dsn file : "{filename}": {e.strerror}')
+
     return dsn
 
 

--- a/query_exporter/config.py
+++ b/query_exporter/config.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from copy import deepcopy
 from logging import Logger
 import os
+from pathlib import Path
 import re
 from typing import (
     Any,
@@ -287,11 +288,9 @@ def _resolve_dsn(dsn: str, env: Environ) -> str:
         _, filename = dsn.split(":", 1)
 
         try:
-            with open(filename) as fd:
-                dsn = fd.read().replace('\n', '')
-
-        except OSError as e:
-            raise ValueError(f'Unable to read dsn file : "{filename}": {e.strerror}')
+            dsn = Path(filename).read_text()
+        except OSError as err:
+            raise ValueError(f'Unable to read dsn file : "{filename}": {err.strerror}')
 
     return dsn
 


### PR DESCRIPTION
Hi,

I don't know if you could have some interest into an option to use a file to provide DSN configuration.

I would like to propose you this change that allow one to use a file to provide the DSN (I understand that it is already possible to use an environment variable).

**Example with the existing env option :** 
dsn: env:ORACLE_DATABASE_DSN

**Proposed option (with file) :** 
dsn: file:/my_dsn_config.conf

Regards,


P.S. : If this is not way to proceed, please let me know. This is all new to me.  Thanks for you project.