### PR TITLE
feat: extend `parameters` to support `matrix`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -268,6 +268,34 @@ Each query definition can have the following keys:
           - param1: 30
             param2: 40
 
+  It can be also in a form of multidimensional matrix of
+  parameters lists to run the query with.
+
+  If a query is specified with parameters as matrix in its ``sql``, it will be run once
+  for every permutation in matrix of parameters, for every interval.
+
+  Variable format in sql query: ``:top_level_key__inner_key``
+
+  .. code:: yaml
+
+      query:
+        databases: [db]
+        metrics: [apps_count]
+        sql: |
+          SELECT COUNT(1) AS apps_count FROM apps_list
+          WHERE os = :os__name AND lang = :lang__name
+        parameters:
+            os:
+              - name: MacOS
+              - name: Linux
+              - name: Windows
+            lang:
+              - name: Python3
+              - name: Java
+              - name: Typescript
+
+  This example will generate 9 sql queries to database with all permutations of ``os`` and ``lang``
+
 ``schedule``:
   a schedule for executing queries at specific times.
 

--- a/README.rst
+++ b/README.rst
@@ -244,10 +244,10 @@ Each query definition can have the following keys:
   Names must match those defined in the ``metrics`` section.
 
 ``parameters``:
-  an optional list of parameters sets to run the query with.
+  an optional list or dictionary of parameters sets to run the query with.
 
-  If a query is specified with parameters in its ``sql``, it will be run once
-  for every set of parameters specified in this list, for every interval.
+  If specified as a list, the query will be run once for every set of
+  parameters specified in this list, for every interval.
 
   Each parameter set must be a dictionary where keys must match parameters
   names from the query SQL (e.g. ``:param``).
@@ -268,13 +268,14 @@ Each query definition can have the following keys:
           - param1: 30
             param2: 40
 
-  It can be also in a form of multidimensional matrix of
+  If specified as a dictionary, it's used as a multidimensional matrix of
   parameters lists to run the query with.
+  The query will be run once for each permutation of parameters.
 
   If a query is specified with parameters as matrix in its ``sql``, it will be run once
   for every permutation in matrix of parameters, for every interval.
 
-  Variable format in sql query: ``:top_level_key__inner_key``
+  Variable format in sql query: ``:{top_level_key}__{inner_key}``
 
   .. code:: yaml
 
@@ -283,18 +284,22 @@ Each query definition can have the following keys:
         metrics: [apps_count]
         sql: |
           SELECT COUNT(1) AS apps_count FROM apps_list
-          WHERE os = :os__name AND lang = :lang__name
+          WHERE os = :os__name AND arch = :os__arch AND lang = :lang__name
         parameters:
             os:
               - name: MacOS
+                arch: arm64
               - name: Linux
+                arch: amd64
               - name: Windows
+                arch: amd64
             lang:
               - name: Python3
               - name: Java
               - name: Typescript
 
-  This example will generate 9 sql queries to database with all permutations of ``os`` and ``lang``
+  This example will generate 9 queries with all permutations of ``os`` and
+  ``lang`` paramters.
 
 ``schedule``:
   a schedule for executing queries at specific times.

--- a/query_exporter/schemas/config.yaml
+++ b/query_exporter/schemas/config.yaml
@@ -230,15 +230,33 @@ definitions:
       parameters:
         title: Parameter sets for the query
         description: >
+          For list format: 
           Queries can have named parameters (in the form ":param").
 
           If they are defined, this must be a list of parameters set for the query.
           The query will be run once for each set.
-        type: array
-        items:
-          type: object
-        minItems: 1
-        uniqueItems: true
+
+          For matrix format
+          Queries can have named matrix of parameters (in the form ":param").
+
+          If it is defined - must be a dict of size 2, each value is an array
+          of possible parameters. The query will run once for each permutation.
+        oneOf:
+          - type: array
+            items:
+              type: object
+            minItems: 1
+            uniqueItems: true
+          - type: object
+            minItems: 1
+            uniqueItems: true
+            patternProperties:
+              .*:
+                type: array
+                items:
+                  type: object
+                minItems: 1
+                uniqueItems: true
       schedule:
         title: Time schedule for executing the query
         description: >

--- a/query_exporter/schemas/config.yaml
+++ b/query_exporter/schemas/config.yaml
@@ -228,19 +228,21 @@ definitions:
         minItems: 1
         uniqueItems: true
       parameters:
-        title: Parameter sets for the query
+        title: Parameter sets for the query (either a list or a dictionary)
         description: >
-          For list format: 
-          Queries can have named parameters (in the form ":param").
+          Specify values for parameters defined in the query.
 
-          If they are defined, this must be a list of parameters set for the query.
-          The query will be run once for each set.
+          Parameters are specified in the form ":param".
 
-          For matrix format
-          Queries can have named matrix of parameters (in the form ":param").
+          The value of this config can be
 
-          If it is defined - must be a dict of size 2, each value is an array
-          of possible parameters. The query will run once for each permutation.
+          - a list of dictionaries mapping parameter names to values.
+            The query is run once for each entry in the list.
+
+          - a dictionary mapping names to a list of dictionaries mapping sub-names and values.
+            In this case, the parameter name format is ":key__subkey".
+
+            The query is executed once for every combination of entries from the top level keys.
         oneOf:
           - type: array
             items:

--- a/query_exporter/tests/test_config.py
+++ b/query_exporter/tests/test_config.py
@@ -4,6 +4,7 @@ import pytest
 import yaml
 
 from ..config import (
+    _get_parameters_sets,
     _resolve_dsn,
     ConfigError,
     DB_ERRORS_METRIC_NAME,
@@ -937,3 +938,108 @@ class TestResolveDSN:
             _resolve_dsn(details, {})
             == "postgresql:///mydb?foo=a+value&bar=another%2Fvalue"
         )
+
+
+class TestGetParametersSets:
+    def test_list(self):
+        params = [
+            {
+                "param1": 100,
+                "param2": "foo",
+            },
+            {
+                "param1": 200,
+                "param2": "bar",
+            },
+        ]
+        assert list(_get_parameters_sets(params)) == params
+
+    def test_dict(self):
+        params = {
+            "param1": [
+                {
+                    "sub1": 100,
+                    "sub2": "foo",
+                },
+                {
+                    "sub1": 200,
+                    "sub2": "bar",
+                },
+            ],
+            "param2": [
+                {
+                    "sub3": "a",
+                    "sub4": False,
+                },
+                {
+                    "sub3": "b",
+                    "sub4": True,
+                },
+            ],
+            "param3": [
+                {
+                    "sub5": "X",
+                },
+                {
+                    "sub5": "Y",
+                },
+            ],
+        }
+        assert list(_get_parameters_sets(params)) == [
+            {
+                "param1__sub1": 100,
+                "param1__sub2": "foo",
+                "param2__sub3": "a",
+                "param2__sub4": False,
+                "param3__sub5": "X",
+            },
+            {
+                "param1__sub1": 100,
+                "param1__sub2": "foo",
+                "param2__sub3": "a",
+                "param2__sub4": False,
+                "param3__sub5": "Y",
+            },
+            {
+                "param1__sub1": 100,
+                "param1__sub2": "foo",
+                "param2__sub3": "b",
+                "param2__sub4": True,
+                "param3__sub5": "X",
+            },
+            {
+                "param1__sub1": 100,
+                "param1__sub2": "foo",
+                "param2__sub3": "b",
+                "param2__sub4": True,
+                "param3__sub5": "Y",
+            },
+            {
+                "param1__sub1": 200,
+                "param1__sub2": "bar",
+                "param2__sub3": "a",
+                "param2__sub4": False,
+                "param3__sub5": "X",
+            },
+            {
+                "param1__sub1": 200,
+                "param1__sub2": "bar",
+                "param2__sub3": "a",
+                "param2__sub4": False,
+                "param3__sub5": "Y",
+            },
+            {
+                "param1__sub1": 200,
+                "param1__sub2": "bar",
+                "param2__sub3": "b",
+                "param2__sub4": True,
+                "param3__sub5": "X",
+            },
+            {
+                "param1__sub1": 200,
+                "param1__sub2": "bar",
+                "param2__sub3": "b",
+                "param2__sub4": True,
+                "param3__sub5": "Y",
+            },
+        ]


### PR DESCRIPTION
Hey @albertodonato, first of all thank you for this exporter, it is awesome.

There is one feature, that i lack, so i implemented it myself and it would be nice if You consider including it in to the `main` branch :3

The problem:
I needed to get items prices in our tables for different marketplaces & for different price ranges. With current `parameters` property i could only specify price ranges, and copy query for each marketplace

The solution:
I come up with `parameters_matrix` (similar to github action's matrix) which will run query for each permutation of each matrix dimension.

Example with parameters:
```yaml
      query_amazon:
        databases: [db]
        metrics: [total_amount]
        sql: |
          select 
            count(1) AS total_amount, 
            "amazon" as marketplace, 
            concat(:price__low, '-', :price__high) aas range
          from items
          where 
            mp = "amazon" and 
            price > :price__low and 
            price <= :price__high;
        parameters:
          - low: 0
            high: 100
          - low: 100
            high: 200
      query_ebay:
        databases: [db]
        metrics: [total_amount]
        sql: |
          select 
            count(1) AS total_amount, 
            "amazon" as marketplace, 
            concat(:price__low, '-', :price__high) aas range
          from items
          where 
            mp = "ebay" and 
            price > :price__low and 
            price <= :price__high;
        parameters:
          - low: 0
            high: 100
          - low: 100
            high: 200
```

Example with `parameters_matrix`:
```yaml
      query:
        databases: [db]
        metrics: [total_amount]
        sql: |
          select 
            count(1) AS total_amount, 
            mp as marketplace, 
            concat(:price__low, '-', :price__high) aas range
          from items
          where 
            mp = :mp__name and 
            price > :price__low and 
            price <= :price__high;
        parameters_matrix:
            mp:
              - name: amazon
              - name: ebay
            price:
              - low: 0
                high: 100
              - low: 100
                high: 200
```

I have added:
- implementation
- new test cases
- docs

Any feedback would be much appreciated :)

P.S. I am no python dev, so sorry for bad code)