### PR TITLE
Bugfix- Added support for ODBC version 17 using argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ RUN mv instantclient*/* /opt/oracle/instantclient
 
 
 FROM python:3.10-slim-bullseye
+ARG ODBC_DRIVER_VERSION=18
+ENV ODBC_DRIVER=msodbcsql${ODBC_DRIVER_VERSION}
 
 RUN apt-get update && \
     apt-get full-upgrade -y && \
@@ -49,7 +51,7 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg && \
     (. /etc/os-release; echo "deb https://packages.microsoft.com/debian/$VERSION_ID/prod $VERSION_CODENAME main") > /etc/apt/sources.list.d/mssql-release.list && \
     apt-get update && \
-    ACCEPT_EULA=Y apt-get install -y --no-install-recommends msodbcsql18 && \
+    ACCEPT_EULA=Y apt-get install -y --no-install-recommends $ODBC_DRIVER && \
     rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man && \
     apt-get clean
 

--- a/README.rst
+++ b/README.rst
@@ -556,7 +556,7 @@ where ``$CONFIG_FILE`` is the absolute path of the configuration file to
 use. Note that the image expects the file to be available as ``/config.yaml``
 in the container.
 
-In case you want to support other ODBC version simply build the image using --build-arg VERSION_NUMBER:
+For other ODBC versions, build the image with --build-arg VERSION_NUMBER:
   docker build --build-arg ODBC_DRIVER_VERSION=17
 
 The image has support for connecting the following databases:

--- a/README.rst
+++ b/README.rst
@@ -556,6 +556,9 @@ where ``$CONFIG_FILE`` is the absolute path of the configuration file to
 use. Note that the image expects the file to be available as ``/config.yaml``
 in the container.
 
+In case you want to support other ODBC version simply build the image using --build-arg VERSION_NUMBER:
+  docker build --build-arg ODBC_DRIVER_VERSION=17
+
 The image has support for connecting the following databases:
 
 - PostgreSQL (``postgresql://``)


### PR DESCRIPTION
Hi @albertodonato, Really liked this exporter!

The problem:
https://github.com/albertodonato/query-exporter/issues/159

The solution:
Add a build argument when building the docker for which ODBC version the user would like to install.

I have added also documentation.
Any feedback would be much appreciated :)
