### PR TITLE
fix columns names in InvalidResultColumnNames being reported the wrong way round

### DIFF
--- a/query_exporter/db.py
+++ b/query_exporter/db.py
@@ -218,7 +218,7 @@ class Query:
         if len(expected_keys) != len(result_keys):
             raise InvalidResultCount(len(expected_keys), len(result_keys))
         if result_keys != expected_keys:
-            raise InvalidResultColumnNames(result_keys, expected_keys)
+            raise InvalidResultColumnNames(expected_keys, result_keys)
         results = []
         for row in query_results.rows:
             values = dict(zip(query_results.keys, row))

--- a/tests/db_test.py
+++ b/tests/db_test.py
@@ -292,8 +292,12 @@ class TestQuery:
             "query", ["db"], [QueryMetric("metric1", ["label1"])], ""
         )
         query_results = QueryResults(["one", "two"], [(1, 2)])
-        with pytest.raises(InvalidResultColumnNames):
+        with pytest.raises(InvalidResultColumnNames) as error:
             query.results(query_results)
+        assert str(error.value) == (
+            "Wrong column names from query: "
+            "expected (label1, metric1), got (one, two)"
+        )
 
 
 class TestQueryResults:
@@ -609,7 +613,7 @@ class TestDataBase:
             await db.execute(query)
         assert (
             str(error.value)
-            == "Wrong column names from query: expected (foo, label), got (label, metric)"
+            == "Wrong column names from query: expected (label, metric), got (foo, label)"
         )
         assert error.value.fatal
 
@@ -618,7 +622,7 @@ class TestDataBase:
         """Traceback are logged as debug messages."""
         query = Query(
             "query",
-            20,
+            ["db"],
             [QueryMetric("metric", [])],
             "SELECT 1 AS metric",
         )


### PR DESCRIPTION
Hi,

The parameters for InvalidResultColumnNames are `(expected, got)`, but they are called as `(result_keys, expected_keys)`. This leads to a slightly confusing error message if you get your query wrong.

Hope this is useful!

Andrew