### PR TITLE
Update the base image to 3.13-slim-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye AS build-image
+FROM python:3.13-slim-bookworm AS build-image
 
 RUN apt-get update
 RUN apt-get full-upgrade -y
@@ -34,7 +34,7 @@ RUN mkdir -p /opt/oracle/instantclient
 RUN mv instantclient*/* /opt/oracle/instantclient
 
 
-FROM python:3.10-slim-bullseye
+FROM python:3.13-slim-bookworm
 ARG ODBC_DRIVER_VERSION=18
 ENV ODBC_DRIVER=msodbcsql${ODBC_DRIVER_VERSION}
 


### PR DESCRIPTION
The version tagged with 2.10.0 uses a vulnerable version of libexpat1: 2.2.10-2+deb11u5. This version has a CVE-2023-52425 which is fixed in 2.2.10-2+deb11u6.

This PR upgrades the python baseimage  to python:3.13-slim-bookworm, which solves the vulnerability.