### PR TITLE
Fix arm64 Docker image by removing --platform=$BUILDPLATFORM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM python:3.14-slim AS base
+FROM python:3.14-slim AS base
 
 RUN apt-get update && apt-get full-upgrade -y
 
@@ -21,7 +21,7 @@ WORKDIR /config
 ENTRYPOINT ["query-exporter"]
 
 
-FROM --platform=$BUILDPLATFORM base AS full
+FROM base AS full
 
 ENV BUILD_DEPS=" \
     build-essential \


### PR DESCRIPTION
## Summary

The current Dockerfile uses `--platform=$BUILDPLATFORM` on both `FROM` lines. This forces the build to always use the build machine's architecture (amd64 on GitHub Actions runners), even when building for arm64. The resulting arm64 images contain amd64 binaries and fail to run on actual arm64 hosts.

This was previously reported in #93.

## Fix

Remove `--platform=$BUILDPLATFORM` from both `FROM` lines. This allows `docker buildx` to correctly pull the native base image for each target platform, producing working binaries for both amd64 and arm64.

## Impact

- The CI workflow already sets up QEMU and specifies `platforms: linux/amd64,linux/arm64` — no CI changes needed
- arm64 builds will take longer (QEMU emulation on amd64 runner) but will produce correct native binaries
- amd64 builds are unaffected